### PR TITLE
Polymorphic relation for articles, news and tags

### DIFF
--- a/app/Http/Controllers/ArticlesController.php
+++ b/app/Http/Controllers/ArticlesController.php
@@ -28,6 +28,7 @@ class ArticlesController extends Controller
 
     public function show(Article $article)
     {
+        $article = $article->load('comments');
         return view('articles.show', compact('article'));
     }
 

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -26,7 +26,7 @@ class CommentsController extends Controller
             'commentable_id' => $article->id,
         ]);
 
-        return view('articles.show', compact('article'));
+        return redirect()->route('articles.show', compact('article'));
     }
 
     public  function storeNewsComment(StoreCommentRequest $request, News $news)

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreCommentRequest;
 use App\Models\Article;
 use App\Models\Comment;
+use App\Models\News;
 use Illuminate\Http\Request;
 
 class CommentsController extends Controller
@@ -14,16 +15,31 @@ class CommentsController extends Controller
         $this->middleware('auth');
     }
 
-    public  function store(StoreCommentRequest $request, Article $article)
+    public  function storeArticlesComment(StoreCommentRequest $request, Article $article)
     {
         $validated = $request->validated();
 
         Comment::create([
             'body' => $validated['body'],
             'user_id' => auth()->user()->id,
-            'article_id' => $article->id,
+            'commentable_type' => Article::class,
+            'commentable_id' => $article->id,
         ]);
 
         return view('articles.show', compact('article'));
+    }
+
+    public  function storeNewsComment(StoreCommentRequest $request, News $news)
+    {
+        $validated = $request->validated();
+
+        Comment::create([
+            'body' => $validated['body'],
+            'user_id' => auth()->user()->id,
+            'commentable_type' => News::class,
+            'commentable_id' => $news->id,
+        ]);
+
+        return redirect()->route('news.show', compact('news'));
     }
 }

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -56,6 +56,7 @@ class NewsController extends Controller
 
     public function show(News $news)
     {
+        $news = $news->load('comments');
         return view('news.show', ['newsItem' => $news]);
     }
 

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -5,11 +5,15 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoryNewsRequest;
 use App\Http\Requests\UpdateNewsRequest;
 use App\Models\News;
+use App\Services\TagsSynchronizer;
 
 class NewsController extends Controller
 {
-    public function __construct()
+    private TagsSynchronizer $tagsSynchronizer;
+
+    public function __construct(TagsSynchronizer $tagsSynchronizer)
     {
+        $this->tagsSynchronizer = $tagsSynchronizer;
         $this->middleware('adminPrivileges')->except(['index', 'show']);
     }
     /**
@@ -43,6 +47,10 @@ class NewsController extends Controller
         $newsItem->body = $validated['body'];
         $newsItem->save();
 
+        $tags = collect(array_filter(explode(',', request('tags'))));
+
+        $this->tagsSynchronizer->sync($tags, $newsItem);
+
         return redirect()->route('news.show', ['news' => $newsItem]);
     }
 
@@ -65,6 +73,10 @@ class NewsController extends Controller
         $newsItem->body = $validated['body'];
         $newsItem->img_path = array_key_exists('image-news-item', $validated) ? getPath($validated['image-news-item']) : $newsItem->img_path;
         $newsItem->save();
+
+        $tags = collect(array_filter(explode(',', request('tags'))));
+
+        $this->tagsSynchronizer->sync($tags, $newsItem);
 
         return redirect()->route('news.show', ['news' => $newsItem]);
     }

--- a/app/Http/Controllers/ServicesProcessingController.php
+++ b/app/Http/Controllers/ServicesProcessingController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\InformationCollector;
+
+class ServicesProcessingController extends Controller
+{
+    private $informationCollector;
+
+    public function __construct(InformationCollector $informationCollector)
+    {
+        $this->informationCollector = $informationCollector;
+        $this->middleware('adminPrivileges');
+    }
+
+    public function informationCollectorServices()
+    {
+        $title = 'Информация';
+        $collection = $this->informationCollector->collect();
+        return view('information', compact('title', 'collection'));
+    }
+}

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -8,9 +8,16 @@ class TagsController extends Controller
 {
     public function index(Tag $tag)
     {
-        $articles = $tag->articles()->with('tags')->get();
+        if (request()->routeIs('articles.tags')) {
+            $articles = $tag->articles()->with('tags')->paginate(5);
+            $title = 'Статьи - ' . $tag->title;
+
+            return view('articles.index', compact('articles', 'title'));
+        }
+
+        $news = $tag->news()->with('tags')->paginate(5);
         $title = 'Статьи - ' . $tag->title;
 
-        return view('articles.index', compact('articles', 'title'));
+        return view('news.index', compact('news', 'title'));
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -48,4 +48,19 @@ class Article extends Model
     {
         return $this->changes;
     }
+
+    public function getLensBodyAttribute($query)
+    {
+        return strlen($this->body);
+    }
+
+    public function getHistoriesCountAttribute($query)
+    {
+        return $this->histories()->count();
+    }
+
+    public function getCommentsCountAttribute($query)
+    {
+        return $this->comments()->count();
+    }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -36,7 +36,7 @@ class Article extends Model
 
     public function comments()
     {
-        return $this->hasMany(Comment::class);
+        return $this->morphMany(Comment::class, 'commentable');
     }
 
     public function histories()

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -26,7 +26,7 @@ class Article extends Model
 
     public function tags()
     {
-        return $this->belongsToMany(Tag::class);
+        return $this->morphToMany(Tag::class, 'taggable');
     }
 
     public function isPublished()

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -15,4 +15,9 @@ class Comment extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
 }

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -16,4 +16,9 @@ class News extends Model
         return $this->morphToMany(Tag::class, 'taggable');
     }
 
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+
 }

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -11,4 +11,9 @@ class News extends Model
 
     protected $guarded = [];
 
+    public function tags()
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
+    }
+
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -13,7 +13,12 @@ class Tag extends Model
 
     public function articles()
     {
-        return $this->belongsToMany(Article::class);
+        return $this->morphedByMany(Article::class, 'taggable');
+    }
+
+    public function news()
+    {
+        return $this->morphedByMany(News::class, 'taggable');
     }
 
     public function getRouteKeyName()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,4 +68,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(Comment::class);
     }
+
+    public function articles()
+    {
+        return $this->hasMany(Article::class);
+    }
+
+    public function getArticlesCountAttribute($query)
+    {
+        return $this->articles()->count();
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,7 +46,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         view()->composer('layout.sidebar', function ($view) {
-            $view->with('tagsCloud', \App\Models\Tag::has('articles')->get());
+            $view->with([
+                'articleTagsCloud' => \App\Models\Tag::has('articles')->get(),
+                'newsTagsCloud' => \App\Models\Tag::has('news')->get(),
+            ]);
         });
 
         Blade::if('admin', function () {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Listeners\SendArcticleCreatedNotification;
 use App\Listeners\SendArcticleDeletedNotification;
 use App\Listeners\SendArcticleUpdatedNotification;
+use App\Services\InformationCollector;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
@@ -35,6 +36,10 @@ class AppServiceProvider extends ServiceProvider
             ])
         ->needs('$adminEmail')
         ->giveConfig('mail.adminEmail');
+
+        $this->app->singleton(InformationCollector::class, function () {
+            return new InformationCollector();
+        });
 
     }
 

--- a/app/Services/InformationCollector.php
+++ b/app/Services/InformationCollector.php
@@ -1,0 +1,101 @@
+<?php
+
+
+namespace App\Services;
+
+
+use App\Models\Article;
+use App\Models\News;
+use App\Models\User;
+
+class InformationCollector
+{
+    private $result;
+
+    public function collect()
+    {
+        $this->countArticles();
+        $this->countNews();
+        $this->userWithMaxArticles();
+        $this->shortArticle();
+        $this->longArticle();
+        $this->averageArticlesOfUsers();
+        $this->maxHistoriesChangesArticle();
+        $this->hasMaxCommentsOfArticle();
+
+        return $this->result;
+    }
+
+    private function countArticles()
+    {
+        $this->result['Общее количество статей'] = [
+                'Количество' => Article::count(),
+        ];
+    }
+
+    private function countNews()
+    {
+        $this->result['Общее количество новостей'] = [
+                'Количество' => News::count(),
+        ];
+    }
+
+    private function userWithMaxArticles()
+    {
+        $this->result['ФИО автора, у которого больше всего статей на сайте'] = [
+                'ФИО автора' => User::withCount('articles')->orderBy('articles_count', 'desc')->first()->name,
+        ];
+    }
+
+    private function shortArticle()
+    {
+        $article = Article::all()->each->append('lens_body')->sortBy('lens_body')->first();
+
+        $this->result['Самая короткая статья.'] = [
+                'Количество символов' => $article->lens_body,
+                'Путь' => route('articles.show', ['article' => $article]),
+                'Название статьи' => $article->title,
+        ];
+    }
+
+    private function longArticle()
+    {
+        $article = Article::all()->each->append('lens_body')->sortByDesc('lens_body')->first();
+
+        $this->result['Самая длинная статья.'] = [
+            'Количество символов' => $article->lens_body,
+            'Путь' => route('articles.show', ['article' => $article]),
+            'Название статьи' => $article->title,
+        ];
+    }
+
+    private function averageArticlesOfUsers()
+    {
+        $usersCount = User::all()->each->append('articles_count')->where('articles_count', '>', 0)->count();
+        $articlesCount = User::all()->each->append('articles_count')->where('articles_count', '>', 0)->sum('articles_count');
+
+        $this->result['Средние количество статей у активных пользователей.'] = [
+            'Средние количество статей' => $articlesCount/$usersCount,
+        ];
+    }
+
+    private function maxHistoriesChangesArticle()
+    {
+        $article = Article::all()->each->append('histories_count')->sortBy('histories_count')->last();
+
+        $this->result['Самая непостоянная статья, которую меняли чаще всего'] = [
+            'Путь' => route('articles.show', ['article' => $article]),
+            'Название статьи' => $article->title,
+        ];
+    }
+
+    private function hasMaxCommentsOfArticle()
+    {
+        $article = Article::all()->each->append('comments_count')->sortBy('comments_count')->last();
+
+        $this->result['Самая обсуждаемая статья'] = [
+            'Путь' => route('articles.show', ['article' => $article]),
+            'Название статьи' => $article->title,
+        ];
+    }
+}

--- a/app/Services/InformationCollector.php
+++ b/app/Services/InformationCollector.php
@@ -49,7 +49,7 @@ class InformationCollector
 
     private function shortArticle()
     {
-        $article = Article::all()->each->append('lens_body')->sortBy('lens_body')->first();
+        $article = Article::selectRaw('*, length(body) as length_body')->orderBy('length_body')->first();
 
         $this->result['Самая короткая статья.'] = [
                 'Количество символов' => $article->lens_body,
@@ -60,7 +60,7 @@ class InformationCollector
 
     private function longArticle()
     {
-        $article = Article::all()->each->append('lens_body')->sortByDesc('lens_body')->first();
+        $article = Article::selectRaw('*, length(body) as length_body')->orderByDesc('length_body')->first();
 
         $this->result['Самая длинная статья.'] = [
             'Количество символов' => $article->lens_body,
@@ -71,8 +71,8 @@ class InformationCollector
 
     private function averageArticlesOfUsers()
     {
-        $usersCount = User::all()->each->append('articles_count')->where('articles_count', '>', 0)->count();
-        $articlesCount = User::all()->each->append('articles_count')->where('articles_count', '>', 0)->sum('articles_count');
+        $usersCount = User::has('articles')->count();
+        $articlesCount = Article::count();
 
         $this->result['Средние количество статей у активных пользователей.'] = [
             'Средние количество статей' => $articlesCount/$usersCount,

--- a/app/Services/InformationCollector.php
+++ b/app/Services/InformationCollector.php
@@ -30,22 +30,40 @@ class InformationCollector
 
     private function countArticles()
     {
-        $this->result['Общее количество статей'] = [
-                'Количество' => Article::count(),
+        $this->result[] = [
+            'head' => 'Общее количество статей',
+            'rows' => [
+                [
+                    'description' => 'Количество',
+                    'value' => Article::count(),
+                ],
+            ],
         ];
     }
 
     private function countNews()
     {
-        $this->result['Общее количество новостей'] = [
-                'Количество' => News::count(),
+        $this->result[] = [
+            'head' => 'Общее количество новостей',
+            'rows' => [
+                [
+                    'description' => 'Количество',
+                    'value' => News::count(),
+                ],
+            ],
         ];
     }
 
     private function userWithMaxArticles()
     {
-        $this->result['ФИО автора, у которого больше всего статей на сайте'] = [
-                'ФИО автора' => User::withCount('articles')->orderBy('articles_count', 'desc')->first()->name,
+        $this->result[] = [
+            'head' => 'ФИО автора, у которого больше всего статей на сайте',
+            'rows' => [
+                [
+                    'description' => 'ФИО автора',
+                    'value' => User::withCount('articles')->orderBy('articles_count', 'desc')->first()->name,
+                ],
+            ],
         ];
     }
 
@@ -53,10 +71,22 @@ class InformationCollector
     {
         $article = Article::selectRaw('*, length(body) as length_body')->orderBy('length_body')->first();
 
-        $this->result['Самая короткая статья.'] = [
-                'Количество символов' => $article->lens_body,
-                'Путь' => route('articles.show', ['article' => $article]),
-                'Название статьи' => $article->title,
+        $this->result[] = [
+            'head' => 'Самая короткая статья.',
+            'rows' => [
+                [
+                    'description' => 'Количество символов',
+                    'value' => $article->lens_body,
+                ],
+                [
+                    'description' => 'Путь',
+                    'value' => route('articles.show', ['article' => $article]),
+                ],
+                [
+                    'description' => 'Название статьи',
+                    'value' => $article->title,
+                ],
+            ],
         ];
     }
 
@@ -64,10 +94,22 @@ class InformationCollector
     {
         $article = Article::selectRaw('*, length(body) as length_body')->orderByDesc('length_body')->first();
 
-        $this->result['Самая длинная статья.'] = [
-            'Количество символов' => $article->lens_body,
-            'Путь' => route('articles.show', ['article' => $article]),
-            'Название статьи' => $article->title,
+        $this->result[] = [
+            'head' => 'Самая длинная статья.',
+            'rows' => [
+                [
+                    'description' => 'Количество символов',
+                    'value' => $article->lens_body,
+                ],
+                [
+                    'description' => 'Путь',
+                    'value' => route('articles.show', ['article' => $article]),
+                ],
+                [
+                    'description' => 'Название статьи',
+                    'value' => $article->title,
+                ],
+            ],
         ];
     }
 
@@ -76,8 +118,14 @@ class InformationCollector
         $usersCount = User::has('articles')->count();
         $articlesCount = Article::count();
 
-        $this->result['Средние количество статей у активных пользователей.'] = [
-            'Средние количество статей' => $articlesCount/$usersCount,
+        $this->result[] = [
+            'head' => 'Средние количество статей у активных пользователей.',
+            'rows' => [
+                [
+                    'description' => 'Средние количество статей',
+                    'value' => $articlesCount/$usersCount,
+                ],
+            ],
         ];
     }
 
@@ -85,9 +133,18 @@ class InformationCollector
     {
         $article = HistoryArticle::selectRaw('article_id, count(*) as count_articles')->groupBy('article_id')->orderByDesc('count_articles')->first()->article;
 
-        $this->result['Самая непостоянная статья, которую меняли чаще всего'] = [
-            'Путь' => route('articles.show', ['article' => $article]),
-            'Название статьи' => $article->title,
+        $this->result[] = [
+            'head' => 'Самая непостоянная статья, которую меняли чаще всего',
+            'rows' => [
+                [
+                    'description' => 'Путь',
+                    'value' => route('articles.show', ['article' => $article]),
+                ],
+                [
+                    'description' => 'Название статьи',
+                    'value' => $article->title,
+                ],
+            ],
         ];
     }
 
@@ -102,9 +159,18 @@ class InformationCollector
 
         $article = Article::find($article_id);
 
-        $this->result['Самая обсуждаемая статья'] = [
-            'Путь' => route('articles.show', ['article' => $article]),
-            'Название статьи' => $article->title,
+        $this->result[] = [
+            'head' => 'Самая обсуждаемая статья',
+            'rows' => [
+                [
+                    'description' => 'Путь',
+                    'value' => route('articles.show', ['article' => $article]),
+                ],
+                [
+                    'description' => 'Название статьи',
+                    'value' => $article->title,
+                ],
+            ],
         ];
     }
 }

--- a/app/Services/InformationCollector.php
+++ b/app/Services/InformationCollector.php
@@ -5,6 +5,8 @@ namespace App\Services;
 
 
 use App\Models\Article;
+use App\Models\Comment;
+use App\Models\HistoryArticle;
 use App\Models\News;
 use App\Models\User;
 
@@ -81,7 +83,7 @@ class InformationCollector
 
     private function maxHistoriesChangesArticle()
     {
-        $article = Article::all()->each->append('histories_count')->sortBy('histories_count')->last();
+        $article = HistoryArticle::selectRaw('article_id, count(*) as count_articles')->groupBy('article_id')->orderByDesc('count_articles')->first()->article;
 
         $this->result['Самая непостоянная статья, которую меняли чаще всего'] = [
             'Путь' => route('articles.show', ['article' => $article]),
@@ -91,7 +93,14 @@ class InformationCollector
 
     private function hasMaxCommentsOfArticle()
     {
-        $article = Article::all()->each->append('comments_count')->sortBy('comments_count')->last();
+        $article_id = Comment::where('commentable_type', Article::class)
+            ->selectRaw('commentable_id, count(*) as count_comments')
+            ->groupBy('commentable_id')
+            ->orderByDesc('count_comments')
+            ->first()
+            ->commentable_id;
+
+        $article = Article::find($article_id);
 
         $this->result['Самая обсуждаемая статья'] = [
             'Путь' => route('articles.show', ['article' => $article]),

--- a/database/migrations/2021_06_15_130910_create_comments_table.php
+++ b/database/migrations/2021_06_15_130910_create_comments_table.php
@@ -16,9 +16,9 @@ class CreateCommentsTable extends Migration
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->text('body');
+            $table->morphs('commentable');
             $table->timestamps();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->foreignId('article_id')->constrained()->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2021_06_30_085939_create_taggables_table.php
+++ b/database/migrations/2021_06_30_085939_create_taggables_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateArticleTagTable extends Migration
+class CreateTaggablesTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,10 +13,10 @@ class CreateArticleTagTable extends Migration
      */
     public function up()
     {
-        Schema::create('article_tag', function (Blueprint $table) {
-            $table->foreignId('article_id')->constrained()->onDelete('cascade');
+        Schema::create('taggables', function (Blueprint $table) {
             $table->foreignId('tag_id')->constrained()->onDelete('cascade');
-            $table->primary(['article_id', 'tag_id']);
+            $table->morphs('taggable');
+            $table->primary(['tag_id', 'taggable_id', 'taggable_type']);
         });
     }
 
@@ -27,6 +27,6 @@ class CreateArticleTagTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('article_tag');
+        Schema::dropIfExists('taggables');
     }
 }

--- a/resources/views/articles/create.blade.php
+++ b/resources/views/articles/create.blade.php
@@ -15,17 +15,7 @@
 
                 @include('articles.form')
 
-                <div class="form-group">
-                    <label for="tagsArticle">Тэги</label>
-                    <input
-                        type="text"
-                        class="form-control"
-                        id="tagsArticle"
-                        placeholder="тэг1,тэг2,тэг3...."
-                        name="tags"
-                        value="{{old('tags')}}"
-                    >
-                </div>
+                @include('tags.form_element')
 
                 <button type="submit" class="btn btn-primary">Сохранить статью</button>
             </form>

--- a/resources/views/articles/edit.blade.php
+++ b/resources/views/articles/edit.blade.php
@@ -15,17 +15,8 @@
             <form method="post" action="{{ route('articles.update', ['article' => $article]) }}">
                 @method('PATCH')
                 @include('articles.form', ['checked' => ($article->published ? 'checked' : '')])
-                <div class="form-group">
-                    <label for="tagsArticle">Тэги</label>
-                    <input
-                        type="text"
-                        class="form-control"
-                        id="tagsArticle"
-                        placeholder="тэг1,тэг2,тэг3...."
-                        name="tags"
-                        value="{{old('tags', $article->tags->pluck('title')->implode(',') ?? '')}}"
-                    >
-                </div>
+
+                @include('tags.form_element', ['tags' => $article->tags])
 
                 <button type="submit" class="btn btn-primary">Изменить статью</button>
             </form>

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -13,7 +13,12 @@
             <p>{{$article->body}}</p>
         </div><!-- /.blog-post -->
 
-        @include('comments.show')
+        <div class="comments">
+            @include('comments.show', ['comments' => $article->comments])
+            <form method="post" action="{{ route('comments.store_articles_comment', ['article' => $article]) }}">
+                @include('comments.form')
+            </form>
+        </div>
 
     </div><!-- /.blog-main -->
 

--- a/resources/views/comments/form.blade.php
+++ b/resources/views/comments/form.blade.php
@@ -1,10 +1,8 @@
 
-<form method="post" action="{{ route('comments.store', ['article' => $article]) }}">
-    @csrf
-    <div class="form-group">
-        <label for="bodyComment">Добавить комментарий</label>
-        <textarea class="form-control" id="bodyComment" rows="5" name="body"></textarea>
-    </div>
+@csrf
+<div class="form-group">
+    <label for="bodyComment">Добавить комментарий</label>
+    <textarea class="form-control" id="bodyComment" rows="5" name="body"></textarea>
+</div>
 
-    <button type="submit" class="btn btn-primary">Добавить комментарий</button>
-</form>
+<button type="submit" class="btn btn-primary">Добавить комментарий</button>

--- a/resources/views/comments/show.blade.php
+++ b/resources/views/comments/show.blade.php
@@ -1,6 +1,2 @@
-<div class="comments">
     <h3>Комментарии:</h3>
-    @each('comments.item', $article->comments, 'comment', 'comments.empty')
-
-    @include('comments.form')
-</div>
+    @each('comments.item', $comments, 'comment', 'comments.empty')

--- a/resources/views/information.blade.php
+++ b/resources/views/information.blade.php
@@ -1,0 +1,34 @@
+@extends('layout.master')
+
+@section('title', $title)
+
+@section('content')
+
+    <div class="col-md-8 blog-main">
+
+        <div class="blog-post">
+            <h2 class="blog-post-title">Информация о портале</h2>
+
+            <table class="table ">
+                @foreach($collection as $description => $collectItem)
+                    <thead>
+                        <tr class="table-info">
+                            <th scope="col"  colspan="2">{{$description}}</th>
+                        </tr>
+                    </thead>
+                    @foreach($collectItem as $key => $item)
+                        <tbody>
+                        <tr>
+                            <td>{{$key}}</td>
+                            <td class="text-center">{{$item}}</td>
+                        </tr>
+                        </tbody>
+                    @endforeach
+                @endforeach
+            </table>
+
+        </div><!-- /.blog-post -->
+
+    </div><!-- /.blog-main -->
+
+@endsection

--- a/resources/views/information.blade.php
+++ b/resources/views/information.blade.php
@@ -10,17 +10,17 @@
             <h2 class="blog-post-title">Информация о портале</h2>
 
             <table class="table ">
-                @foreach($collection as $description => $collectItem)
+                @foreach($collection as $collectItem)
                     <thead>
                         <tr class="table-info">
-                            <th scope="col"  colspan="2">{{$description}}</th>
+                            <th scope="col"  colspan="2">{{$collectItem['head']}}</th>
                         </tr>
                     </thead>
-                    @foreach($collectItem as $key => $item)
+                    @foreach($collectItem['rows'] as $row)
                         <tbody>
                         <tr>
-                            <td>{{$key}}</td>
-                            <td class="text-center">{{$item}}</td>
+                            <td>{{$row['description']}}</td>
+                            <td class="text-center">{{$row['value']}}</td>
                         </tr>
                         </tbody>
                     @endforeach

--- a/resources/views/layout/nav.blade.php
+++ b/resources/views/layout/nav.blade.php
@@ -50,6 +50,7 @@
                     <a class="nav-item nav-link" href="{{ route('admin.articles') }}">Список статей</a>
                     <a class="nav-item nav-link" href="{{ route('admin.feedback') }}">Обратная связь</a>
                     <a class="nav-item nav-link" href="{{ route('news.create') }}">Создать новость</a>
+                    <a class="nav-item nav-link" href="{{ route('information') }}">Информация о портале</a>
                 </div>
             </div>
         </nav>

--- a/resources/views/layout/sidebar.blade.php
+++ b/resources/views/layout/sidebar.blade.php
@@ -1,6 +1,9 @@
 <aside class="col-md-4 blog-sidebar">
     <div class="p-3">
-        <h4 class="font-italic">Облако тэгов</h4>
-        @include('articles.tags', ['tags' => $tagsCloud])
+        <h3 class="font-italic">Облако тэгов</h3>
+        <h4 class="font-italic">Статьи:</h4>
+        @include('articles.tags', ['tags' => $articleTagsCloud])
+        <h4 class="font-italic">Новости:</h4>
+        @include('news.tags', ['tags' => $newsTagsCloud])
     </div>
 </aside><!-- /.blog-sidebar -->

--- a/resources/views/news/create.blade.php
+++ b/resources/views/news/create.blade.php
@@ -13,6 +13,7 @@
 
             <form method="post" action="{{ route('news.store') }}" enctype="multipart/form-data">
                 @include('news.form')
+                @include('tags.form_element')
                 <button type="submit" class="btn btn-primary">Создать новость</button>
             </form>
 

--- a/resources/views/news/edit.blade.php
+++ b/resources/views/news/edit.blade.php
@@ -15,6 +15,7 @@
             <form method="post" action="{{ route('news.update', ['news' => $newsItem]) }}"  enctype="multipart/form-data">
                 @method('PATCH')
                 @include('news.form')
+                @include('tags.form_element', ['tags' => $newsItem->tags])
                 <button type="submit" class="btn btn-primary">Изменить новость</button>
             </form>
             <form method="post" action="{{ route('news.destroy', ['news' => $newsItem]) }}">

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -15,6 +15,13 @@
             <p>{{$newsItem->body}}</p>
         </div><!-- /.blog-post -->
 
+        <div class="comments">
+            @include('comments.show', ['comments' => $newsItem->comments])
+            <form method="post" action="{{ route('comments.store_news_comment', ['news' => $newsItem]) }}">
+                @include('comments.form')
+            </form>
+        </div>
+
     </div><!-- /.blog-main -->
 
 @endsection

--- a/resources/views/news/tags.blade.php
+++ b/resources/views/news/tags.blade.php
@@ -1,0 +1,11 @@
+@php
+    $tags = $tags ?? collect();
+@endphp
+
+@if($tags->isNotEmpty())
+    <div>
+        @foreach($tags as $tag)
+            <a href='{{route('news.tags', ['tag' => $tag->title ])}}' class='badge badge-secondary'>{{ $tag->title }}</a>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/tags/form_element.blade.php
+++ b/resources/views/tags/form_element.blade.php
@@ -1,0 +1,15 @@
+<div class="form-group">
+    <label for="tags">Тэги</label>
+    <input
+        type="text"
+        class="form-control"
+        id="tags"
+        placeholder="тэг1,тэг2,тэг3...."
+        name="tags"
+        @if($tags ?? null)
+            value="{{old('tags', $tags->pluck('title')->implode(',') ?? '')}}"
+        @else
+            value="{{old('tags')}}"
+        @endif
+    >
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ Route::get('/admin/articles', [\App\Http\Controllers\ArticlesAdminController::cl
 Route::get('/admin/articles/{article}/edit', [\App\Http\Controllers\ArticlesController::class, 'edit'])->name('admin.articles.edit');
 Route::get('/admin/articles/{article}/history', [\App\Http\Controllers\ArticlesController::class, 'history'])->name('admin.articles.history')->middleware('adminPrivileges');
 
-Route::post('/articles/{article}/comments', [\App\Http\Controllers\CommentsController::class, 'store'])->name('comments.store');
+Route::post('/articles/{article}/comments', [\App\Http\Controllers\CommentsController::class, 'storeArticlesComment'])->name('comments.store_articles_comment');
+Route::post('/news/{news}/comments', [\App\Http\Controllers\CommentsController::class, 'storeNewsComment'])->name('comments.store_news_comment');
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,11 +17,7 @@ Route::get('/about', function () {
     return view('about', compact('title'));
 })->name('about');
 
-Route::get('information', function (\App\Services\InformationCollector $informationCollector) {
-    $title = 'Информация';
-    $collection = $informationCollector->collect();
-    return view('information', compact('title', 'collection'));
-})->name('information')->middleware('adminPrivileges');
+Route::get('information', [\App\Http\Controllers\ServicesProcessingController::class, 'informationCollectorServices'])->name('information');
 
 Route::get('/admin/feedback', [ContactsController::class, 'index'])->name('admin.feedback')->middleware('adminPrivileges');
 Route::get('/contacts', [ContactsController::class, 'create'])->name('contacts.create');

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,12 @@ Route::get('/about', function () {
     return view('about', compact('title'));
 })->name('about');
 
+Route::get('information', function (\App\Services\InformationCollector $informationCollector) {
+    $title = 'Информация';
+    $collection = $informationCollector->collect();
+    return view('information', compact('title', 'collection'));
+})->name('information')->middleware('adminPrivileges');
+
 Route::get('/admin/feedback', [ContactsController::class, 'index'])->name('admin.feedback')->middleware('adminPrivileges');
 Route::get('/contacts', [ContactsController::class, 'create'])->name('contacts.create');
 Route::post('/contacts', [ContactsController::class, 'store'])->name('contacts.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ContactsController;
 Route::get('/', [ArticlesController::class, 'index'])->name('home');
 Route::resource('/articles', ArticlesController::class)->except(['index']);
 Route::get('/articles/tags/{tag}', [TagsController::class, 'index'])->name('articles.tags');
+Route::get('/news/tags/{tag}', [TagsController::class, 'index'])->name('news.tags');
 
 Route::resource('/news', \App\Http\Controllers\NewsController::class);
 


### PR DESCRIPTION
Реализуйте возможность привязывать теги к любым моделям (полиморфные связи). 

Добавьте возможность указывать теги для новостей. 

На странице создания и редактирования новости примените созданный ранее сервис для сохранения и привязки тегов.
На странице отображения по тегам теперь видны и новости, и статьи двумя отдельными списками без постраничной навигации. При этом отображаются только эти две модели.  Если привязать теги ещё и, например, к пользователям, то они не должны появиться на этой странице. 
